### PR TITLE
Do not pass BOOL values as parameters

### DIFF
--- a/bq/valuetracker.go
+++ b/bq/valuetracker.go
@@ -16,16 +16,23 @@ func NewBigQueryNamedTracker() *BigQueryNamedTracker {
 }
 
 func (t *BigQueryNamedTracker) AddValue(val interface{}) string {
-	if val == nil {
+	switch v := val.(type) {
+	case nil:
 		// NULL cannot be passed as a parameter
 		return "NULL"
-	}
-	for _, v := range t.Values {
-		if reflect.DeepEqual(v.Value, val) {
-			return "@" + v.Name
+	case bool:
+		if v {
+			return "TRUE"
 		}
+		return "FALSE"
+	default:
+		for _, v := range t.Values {
+			if reflect.DeepEqual(v.Value, val) {
+				return "@" + v.Name
+			}
+		}
+		name := fmt.Sprintf("v%dt", len(t.Values))
+		t.Values = append(t.Values, bigquery.QueryParameter{Name: name, Value: val})
+		return "@" + name
 	}
-	name := fmt.Sprintf("v%dt", len(t.Values))
-	t.Values = append(t.Values, bigquery.QueryParameter{Name: name, Value: val})
-	return "@" + name
 }


### PR DESCRIPTION
``` `field` IS @v0t ``` is invalid SQL since after `IS` a literal is expected
TRUE/FALSE are almost as long as `@v{\d+}t` anyways so its probably best not to pass them as parameters rather than replace `IS` with `=` operator for bool comparison