### PR TITLE
exclude comprehension iteration variable from identity access tracker

### DIFF
--- a/cel2sql_test.go
+++ b/cel2sql_test.go
@@ -546,6 +546,12 @@ func TestConvert(t *testing.T) {
 			idents: []string{"pages"},
 		},
 		{
+			name:   "two_level_map",
+			args:   args{source: `pages.map(p, ["Title1", "Title2"].map(t, p.title + " " + t))`},
+			want:   "ARRAY(SELECT ARRAY(SELECT `p`.`title` || \" \" || `t` FROM [\"Title1\", \"Title2\"] AS t) FROM `pages` AS p)",
+			idents: []string{"pages"},
+		},
+		{
 			name:   "mapFilter",
 			args:   args{source: `pages.map(p, p.language == "english", p.title)`},
 			want:   "ARRAY(SELECT `p`.`title` FROM `pages` AS p WHERE `p`.`language` = \"english\")",

--- a/cel2sql_test.go
+++ b/cel2sql_test.go
@@ -57,6 +57,7 @@ func TestConvert(t *testing.T) {
 		want                 string
 		wantCompileErr       bool
 		wantErr              bool
+		idents               []string
 	}{
 		{
 			name: "startsWith",
@@ -361,44 +362,52 @@ func TestConvert(t *testing.T) {
 			want: `TIMESTAMP_TRUNC(TIMESTAMP("2023-09-01 18:00:00"), WEEK)`,
 		},
 		{
-			name: "fieldSelect",
-			args: args{source: `page.title == "test"`},
-			want: "`page`.`title` = \"test\"",
+			name:   "fieldSelect",
+			args:   args{source: `page.title == "test"`},
+			want:   "`page`.`title` = \"test\"",
+			idents: []string{"page.title"},
 		},
 		{
-			name: "fieldSelect_startsWith",
-			args: args{source: `page.title.startsWith("test")`},
-			want: "STARTS_WITH(`page`.`title`, \"test\")",
+			name:   "fieldSelect_startsWith",
+			args:   args{source: `page.title.startsWith("test")`},
+			want:   "STARTS_WITH(`page`.`title`, \"test\")",
+			idents: []string{"page.title"},
 		},
 		{
-			name: "fieldSelect_add",
-			args: args{source: `trigram.cell[0].page_count + 1`},
-			want: "`trigram`.`cell`[OFFSET(0)].`page_count` + 1",
+			name:   "fieldSelect_add",
+			args:   args{source: `trigram.cell[0].page_count + 1`},
+			want:   "`trigram`.`cell`[OFFSET(0)].`page_count` + 1",
+			idents: []string{"trigram.cell", ".page_count"},
 		},
 		{
-			name: "fieldSelect_concatString",
-			args: args{source: `trigram.cell[0].sample[0].title + "test"`},
-			want: "`trigram`.`cell`[OFFSET(0)].`sample`[OFFSET(0)].`title` || \"test\"",
+			name:   "fieldSelect_concatString",
+			args:   args{source: `trigram.cell[0].sample[0].title + "test"`},
+			want:   "`trigram`.`cell`[OFFSET(0)].`sample`[OFFSET(0)].`title` || \"test\"",
+			idents: []string{"trigram.cell", ".sample", ".title"},
 		},
 		{
-			name: "fieldSelect_in",
-			args: args{source: `"test" in trigram.cell[0].value`},
-			want: "\"test\" IN UNNEST(`trigram`.`cell`[OFFSET(0)].`value`)",
+			name:   "fieldSelect_in",
+			args:   args{source: `"test" in trigram.cell[0].value`},
+			want:   "\"test\" IN UNNEST(`trigram`.`cell`[OFFSET(0)].`value`)",
+			idents: []string{"trigram.cell", ".value"},
 		},
 		{
-			name: "safe_fieldSelect_add",
-			args: args{source: `trigram.cell.get(0).page_count + 1`},
-			want: "`trigram`.`cell`[SAFE_OFFSET(0)].`page_count` + 1",
+			name:   "safe_fieldSelect_add",
+			args:   args{source: `trigram.cell.get(0).page_count + 1`},
+			want:   "`trigram`.`cell`[SAFE_OFFSET(0)].`page_count` + 1",
+			idents: []string{"trigram.cell", ".page_count"},
 		},
 		{
-			name: "safe_fieldSelect_concatString",
-			args: args{source: `trigram.cell.get(0).sample.get(0).title + "test"`},
-			want: "`trigram`.`cell`[SAFE_OFFSET(0)].`sample`[SAFE_OFFSET(0)].`title` || \"test\"",
+			name:   "safe_fieldSelect_concatString",
+			args:   args{source: `trigram.cell.get(0).sample.get(0).title + "test"`},
+			want:   "`trigram`.`cell`[SAFE_OFFSET(0)].`sample`[SAFE_OFFSET(0)].`title` || \"test\"",
+			idents: []string{"trigram.cell", ".sample", ".title"},
 		},
 		{
-			name: "safe_fieldSelect_in",
-			args: args{source: `"test" in trigram.cell.get(0).value`},
-			want: "\"test\" IN UNNEST(`trigram`.`cell`[SAFE_OFFSET(0)].`value`)",
+			name:   "safe_fieldSelect_in",
+			args:   args{source: `"test" in trigram.cell.get(0).value`},
+			want:   "\"test\" IN UNNEST(`trigram`.`cell`[SAFE_OFFSET(0)].`value`)",
+			idents: []string{"trigram.cell", ".value"},
 		},
 		{
 			name: "cast_bool",
@@ -456,9 +465,10 @@ func TestConvert(t *testing.T) {
 			want: "ARRAY_LENGTH(`string_list`)",
 		},
 		{
-			name: "inplace_array_exists",
-			args: args{source: `["foo", "bar"].exists(x, x == "foo")`},
-			want: "EXISTS (SELECT * FROM UNNEST([\"foo\", \"bar\"]) AS x WHERE `x` = \"foo\")",
+			name:   "inplace_array_exists",
+			args:   args{source: `["foo", "bar"].exists(x, x == "foo")`},
+			want:   "EXISTS (SELECT * FROM UNNEST([\"foo\", \"bar\"]) AS x WHERE `x` = \"foo\")",
+			idents: []string{},
 		},
 		{
 			name: "filters_exists_equals",
@@ -517,24 +527,28 @@ func TestConvert(t *testing.T) {
 			want: "FALSE AND FALSE AND FALSE AND FALSE AND FALSE",
 		},
 		{
-			name: "map",
-			args: args{source: `pages.map(p, p.title)`},
-			want: "ARRAY(SELECT `p`.`title` FROM `pages` AS p)",
+			name:   "map",
+			args:   args{source: `pages.map(p, p.title)`},
+			want:   "ARRAY(SELECT `p`.`title` FROM `pages` AS p)",
+			idents: []string{"pages"},
 		},
 		{
-			name: "mapFilter",
-			args: args{source: `pages.map(p, p.language == "english", p.title)`},
-			want: "ARRAY(SELECT `p`.`title` FROM `pages` AS p WHERE `p`.`language` = \"english\")",
+			name:   "mapFilter",
+			args:   args{source: `pages.map(p, p.language == "english", p.title)`},
+			want:   "ARRAY(SELECT `p`.`title` FROM `pages` AS p WHERE `p`.`language` = \"english\")",
+			idents: []string{"pages"},
 		},
 		{
-			name: "mapDistinct",
-			args: args{source: `pages.mapDistinct(p, p.title)`},
-			want: "ARRAY(SELECT DISTINCT `p`.`title` FROM `pages` AS p)",
+			name:   "mapDistinct",
+			args:   args{source: `pages.mapDistinct(p, p.title)`},
+			want:   "ARRAY(SELECT DISTINCT `p`.`title` FROM `pages` AS p)",
+			idents: []string{"pages"},
 		},
 		{
-			name: "mapDistinctFilter",
-			args: args{source: `pages.mapDistinct(p, p.language == "english", p.title)`},
-			want: "ARRAY(SELECT DISTINCT `p`.`title` FROM `pages` AS p WHERE `p`.`language` = \"english\")",
+			name:   "mapDistinctFilter",
+			args:   args{source: `pages.mapDistinct(p, p.language == "english", p.title)`},
+			want:   "ARRAY(SELECT DISTINCT `p`.`title` FROM `pages` AS p WHERE `p`.`language` = \"english\")",
+			idents: []string{"pages"},
 		},
 	}
 
@@ -554,7 +568,14 @@ func TestConvert(t *testing.T) {
 			}
 			ext := filters.NewExtension(extOpts...)
 
-			got, err := cel2sql.Convert(ast, cel2sql.WithExtension(ext))
+			identTracker := identTracker(make(map[string]struct{}))
+			got, err := cel2sql.Convert(ast, cel2sql.WithExtension(ext), cel2sql.WithIdentTracker(identTracker))
+			if len(tt.idents) != 0 {
+				assert.Equal(t, len(tt.idents), len(identTracker))
+				for _, i := range tt.idents {
+					assert.Contains(t, identTracker, i)
+				}
+			}
 			if !tt.wantErr && assert.NoError(t, err) {
 				assert.Equal(t, tt.want, got)
 			} else {
@@ -574,4 +595,15 @@ func TestConvert(t *testing.T) {
 			})
 		})
 	}
+}
+
+type identTracker map[string]struct{}
+
+func (t identTracker) AddIdentAccess(rootExpr *cel2sql.Expr, path []string) (res []string) {
+	if rootExpr == nil {
+		t[strings.Join(path, ".")] = struct{}{}
+	} else {
+		t["."+strings.Join(path, ".")] = struct{}{}
+	}
+	return path
 }

--- a/cel2sql_test.go
+++ b/cel2sql_test.go
@@ -584,10 +584,11 @@ func TestConvert(t *testing.T) {
 			identTracker := identTracker(make(map[string]struct{}))
 			got, err := cel2sql.Convert(ast, cel2sql.WithExtension(ext), cel2sql.WithIdentTracker(identTracker))
 			if len(tt.idents) != 0 {
-				assert.Equal(t, len(tt.idents), len(identTracker))
-				for _, i := range tt.idents {
-					assert.Contains(t, identTracker, i)
+				observedIdents := make([]string, 0, len(identTracker))
+				for ident := range identTracker {
+					observedIdents = append(observedIdents, ident)
 				}
+				assert.ElementsMatch(t, tt.idents, observedIdents)
 			}
 			if !tt.wantErr && assert.NoError(t, err) {
 				assert.Equal(t, tt.want, got)

--- a/cel2sql_test.go
+++ b/cel2sql_test.go
@@ -35,6 +35,7 @@ func TestConvert(t *testing.T) {
 			decls.NewVar("string_int_map", decls.NewMapType(decls.String, decls.Int)),
 			decls.NewVar("nullable_string", decls.NewWrapperType(decls.String)),
 			decls.NewVar("nullable_bytes", decls.NewWrapperType(decls.Bytes)),
+			decls.NewVar("nullable_strings", decls.NewListType(decls.NewWrapperType(decls.String))),
 			decls.NewVar("null_var", decls.Null),
 			decls.NewVar("birthday", sqltypes.Date),
 			decls.NewVar("fixed_time", sqltypes.Time),
@@ -220,6 +221,18 @@ func TestConvert(t *testing.T) {
 			name: "nullable_bytes_concat",
 			args: args{source: `nullable_bytes + b"hello"`},
 			want: "`nullable_bytes` || b\"\\150\\145\\154\\154\\157\"",
+		},
+		{
+			name:   "nullable_strings_containsNull",
+			args:   args{source: `nullable_strings.exists(x, x == null)`},
+			want:   "EXISTS (SELECT * FROM UNNEST(`nullable_strings`) AS x WHERE `x` IS NULL)",
+			idents: []string{"nullable_strings"},
+		},
+		{
+			name:   "nullable_strings_containsEquals",
+			args:   args{source: `nullable_strings.exists(x, x.existsEqualsCI(["hello"]))`},
+			want:   "EXISTS (SELECT * FROM UNNEST(`nullable_strings`) AS x WHERE COLLATE(`x`, \"und:ci\") = \"hello\")",
+			idents: []string{"nullable_strings"},
 		},
 		{
 			name: "concatList",


### PR DESCRIPTION
comprehension iteration variable is not an identity the caller is interested in
Also adds support for nullable SQL strings in existsEquals/Starts/Ends/Contains/Regexp conversion