### PR TITLE
translate timestamp(0) to NULL

### DIFF
--- a/cel2sql_test.go
+++ b/cel2sql_test.go
@@ -260,6 +260,11 @@ func TestConvert(t *testing.T) {
 			want: "`scheduled_at` != DATETIME(DATE(\"2021-09-01\"), `fixed_time`)",
 		},
 		{
+			name: "null_timestamp",
+			args: args{source: `created_at == timestamp(0) && created_at != timestamp(0)`},
+			want: "`created_at` IS NULL AND `created_at` IS NOT NULL",
+		},
+		{
 			name: "timestamp",
 			args: args{source: `created_at - duration("60m") <= timestamp(datetime("2021-09-01 18:00:00"), "Asia/Tokyo")`},
 			want: "TIMESTAMP_SUB(`created_at`, INTERVAL 1 HOUR) <= TIMESTAMP(DATETIME(\"2021-09-01 18:00:00\"), \"Asia/Tokyo\")",


### PR DESCRIPTION
go CEL evaluator always evaluates `timestamp_field == null` to false and `timestamp_field != null` to true.

as a workaround, we can use `timestamp_field == timestamp(0)` (which evaluates to true iff `timestamp_field` is null or has zero Unix timestamp value) and `timestamp_field != timestamp(0)` (which evaluates to true iff `timestamp_field` is not null and has non-zero Unix timestamp value)

we need to translate this comparison to `IS NULL` and `IS NOT NULL` for BQ, however.
we will not translate `timestamp('1970-01-01T00:00:00Z')`, however, which can be still be used for comparison with the non-null zero unix timestamp in BQ (although CEL evaluator will not differentiate).